### PR TITLE
Add PWAify to Tools

### DIFF
--- a/README.md
+++ b/README.md
@@ -140,3 +140,4 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [`fetch-sync`](https://github.com/sdgluck/fetch-sync): Proxy Fetch requests through the Background Sync API
 * [`fetch-manifest-json`](https://github.com/hemanth/fetch-manifest-json): Fetch the `mainfest.json` from an URL.
 * [`manifest-json`](https://www.npmjs.com/package/manifest-json): CLI tool for creating `mainfest.json`.
+* [`PWAify`](https://github.com/vladikoff/PWAify): CLI tool to convert your PWA into a cross-platform desktop app. 


### PR DESCRIPTION
Note: the related article [Progressive web apps running as native OS X apps](https://dev.opera.com/articles/pwa-desktop/) would also be a good addition to the list.