### PR TITLE
Add PakWheels PWA

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [MoneyTracker](https://moneytracker.cc/)
 * [Notella](https://github.com/siddharthkp/notella)
 * [Notepad](https://www.amitmerchant.com/notepad/)
+* [PakWheels](https://www.pakwheels.com/)
 * [Paytm Lite](https://paytm.com/)
 * [Pokedex](https://www.pokedex.org/)
 * [PokeQuest Wiki](https://pokequest.wiki/)


### PR DESCRIPTION
The PWA is mobile only for now. If you want to test, open [PakWheels.com](https://www.pakwheels.com) on a phone or change user agent on a desktop.