### PR TITLE
ci: Use `ruby/setup-ruby`

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
-    - uses: actions/setup-ruby@v1
+    - uses: ruby/setup-ruby@v1
       with:
         ruby-version: '2.7'
     - name: Install awesome_bot


### PR DESCRIPTION
- `actions/setup-ruby@v1` is deprecated and currently causes CI to fail