### PR TITLE
ci: Run link checker on Pull Requests

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,6 @@
 name: CI
 
-on: [push]
+on: [push, pull_request]
 
 jobs:
   build:


### PR DESCRIPTION
I made #288, and lack of CI running on pull requests makes it unclear if my fix is a complete one (there could be more errors after the first one is fixed).