### PR TITLE
Update link to 2048 game in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,7 +47,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Bento-starter](https://bento-starter.firebaseapp.com): Open-Source Full-Stack solution for fast PWA development
 * [Best Markdown Editor](https://bestmarkdowneditor.com): undefined
 * [BitMidi](https://bitmidi.com): Listen to your favorite MIDI files.
-* [2048 Game](https://2048game.com/) 2048 Game
+* [2048 Game](https://play2048.co/) 2048 Game
 * [Booksie](https://www.booksie.org/): An open catalog of free picture storybooks for children instantly available for reading.
 * [Brutalist Hacker News](https://brutalisthackernews.com): A Hacker News reader inspired by Brutalist Web design, Cyberpunk, retro computing, Y2K Aesthetics 
 * [Budget Tracker](https://btapp.netlify.com/): Track expenses and analyse if they stick to a budget


### PR DESCRIPTION
Hey there!

I noticed that your repo links to 2048, but not to the official website created by me. Instead, it links to 2048game.com. While 2048game.com is a fork of the original 2048 and therefore also a version of 2048, play2048.co hosts the original version created by me, Gabriele Cirulli, in 2014. It will also receive improvements and updates soon.

I would love for you to consider this change!

Thanks,
Gabriele