### PR TITLE
Add link to 2048 game in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,6 +47,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Bento-starter](https://bento-starter.firebaseapp.com): Open-Source Full-Stack solution for fast PWA development
 * [Best Markdown Editor](https://bestmarkdowneditor.com): undefined
 * [BitMidi](https://bitmidi.com): Listen to your favorite MIDI files.
+* [2048 Game](https://play2048.co/) 2048 Game
 * [Booksie](https://www.booksie.org/): An open catalog of free picture storybooks for children instantly available for reading.
 * [Brutalist Hacker News](https://brutalisthackernews.com): A Hacker News reader inspired by Brutalist Web design, Cyberpunk, retro computing, Y2K Aesthetics 
 * [Budget Tracker](https://btapp.netlify.com/): Track expenses and analyse if they stick to a budget


### PR DESCRIPTION
This is a follow up to #322.

I recently released a new version of [2048](https://play2048.co) and it should now fully support PWA (with the exception of offline capabilities via service-worker, which I plan to add soon). Hopefully it's now fit for inclusion! Let me know :)

Gabriele