### PR TITLE
Add PageGuard - free website health scanner for PWA quality auditing

### DIFF
--- a/README.md
+++ b/README.md
@@ -315,6 +315,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [`msgr`](https://github.com/sdgluck/msgr): Nifty service worker/client message utility
 * [`offline-plugin`](https://github.com/NekR/offline-plugin): Offline plugin (ServiceWorker, AppCache) for webpack (<http://webpack.github.io/>)
 * [`PWA Asset Generator`](https://github.com/elegantapp/pwa-asset-generator): Automates PWA asset generation and image declaration. Automatically generates icon and splash screen images, favicons and mstile images.
+* [`PageGuard`](https://pageguard.org): Free website health scanner that audits performance, accessibility (WCAG 2.1), SEO, and best practices — ideal for verifying PWA quality before launch.
 * [`PWAify`](https://github.com/vladikoff/PWAify): CLI tool to convert your PWA into a cross-platform desktop app.
 * [`serviceworker-rails`](https://github.com/rossta/serviceworker-rails): Plugin to integrate Service Worker with the Rails asset pipeline.
 * [`serviceworker-webpack-plugin`](https://github.com/oliviertassinari/serviceworker-webpack-plugin): Simplifies creation of a service worker to serve your webpack bundles.


### PR DESCRIPTION
## What is PageGuard?

[PageGuard](https://pageguard.org) is a free website health scanner that checks:

- **Performance** — Core Web Vitals (LCP, CLS, FCP, TTFB)
- **Accessibility** — WCAG 2.1 compliance (important for ADA compliance)
- **SEO** — meta tags, structured data, canonical URLs
- **Best Practices** — security headers, HTTPS, robots.txt

## Why it belongs in the Tools section

PWA developers often need a quick, free way to audit their apps before launch. PageGuard provides an all-in-one health score out of 100, making it easy to identify and fix issues — no technical setup required.

It's particularly useful for validating that your PWA meets accessibility standards (WCAG 2.1 / ADA Title II) which are increasingly required by law.

## Addition

Added to the **Tools** section in alphabetical order (between `PWA Asset Generator` and `PWAify`).