### PR TITLE
Add Foldergram to Audio and Video apps

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 ### Audio and Video
 
 * [BitMidi](https://bitmidi.com): Listen to your favorite MIDI files.
+* [Foldergram](https://github.com/foldergram/foldergram): Local-only photo and video gallery for folders, with an Instagram-inspired browsing pattern.
 * [guitar-tuner](https://aerotwist.com/blog/guitar-tuner/): Aerotwist Guitar Tuner
 * [Joybox](https://joybox.rosano.ca): A pinboard for audiovisual media.
 * [Kudoflix](https://kudoflix.com): Online video editor.


### PR DESCRIPTION
I've added Foldergram to the Audio and Video apps section. Foldergram is a self-hosted, local-only photo and video gallery that organizes folders into an Instagram-inspired feed. It is a Progressive Web App (PWA) that offers a lightning-fast browsing experience for local media.