### PR TITLE
Add Remove Audio to Audio and Video

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,6 +69,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Wave-PD1](https://alexgibson.github.io/wavepad/): Synth toy.
 * [X Sound](https://korilakkuma.github.io/X-Sound/): Online keyboard synth.
 * [Youtube Music](https://music.youtube.com/): Music streaming via YouTube.
+* [Remove Audio](https://remove-audio.com): Browser-based tool to strip the soundtrack from any video locally with WebAssembly and FFmpeg.wasm. No uploads, no sign-up, batch up to 20 clips.
 
 ### Business and Finance
 


### PR DESCRIPTION
Adds Remove Audio under Apps > Audio and Video.

Remove Audio is a free browser-based PWA that strips the audio from any video locally with WebAssembly and FFmpeg.wasm. No uploads, no sign-up, no watermarks. It fits this list because the entire workflow runs in-browser as a progressive web app: works offline after first load, installable on iOS/Android/desktop, and processes files without leaving the device.

Existing entries like Kudoflix and VideoTrim.app sit in the same Audio and Video subsection - this is the closest fit.