### PR TITLE
Add Free Background Remover to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -200,6 +200,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [2brew](https://2brew.github.io/): PWA timer for coffee brewing
 * [AlarmDJ](https://alarmdj.com): Online alarm clock that plays MP3 files or YouTube videos.
 * [Anonynote](https://anonynote.org): Note-taking app.
+* [browser-based background removal tool](https://free-background-remover.com): AI background remover that runs locally in the browser, no upload, sign-up, or watermark.
 * [BulkPicTools](https://bulkpictools.com): Privacy-first, browser-side bulk image optimizer and editor.
 * [Calculator](https://calculator-app-tau.vercel.app/): A calculator app with theme switcher
 * [Emoji Log](https://emojilog.rosano.ca): Personal tracker


### PR DESCRIPTION
Adds Free Background Remover (https://free-background-remover.com) to the Tools and Utilities subsection.

It fits this list because it is a browser-based, install-free utility: the AI segmentation model runs locally so photos never leave the device, and the page works offline once loaded. Sits alongside BulkPicTools and Vizua in the same section. No upload, no sign-up, no watermark.