### PR TITLE
Add Terraform Academy to Education and Reading

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,6 +133,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Kommit](https://kommit.rosano.ca): Create flashcards and learn them with spaced-repetition.
 * [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/): Slow down & loop YouTube videos for music practice with progressive speed training.
 * [Swahili Dictionary](https://swahili-dictionary.com/): Offline Swahili-English-Swahili dictionary
+* [Terraform Academy](https://www.terraformacademy.app/): Installable PWA for learning Terraform and infrastructure as code. Includes interactive labs, certification prep for AWS, GCP, Azure, Docker, Kubernetes and HashiCorp, an AI coach, progress tracking, and offline access through service workers.
 * [Timetable](https://leoherrmann.github.io/timetable/): Interactive editable timetable.
 * [Tutor Portfolio PWA](https://englishextra.gitlab.io/): ???
 * [Unalengua IPA Translator](https://unalengua.com/ipa): Translate to IPA.


### PR DESCRIPTION
Adds Terraform Academy under the Education and Reading section.

Terraform Academy is an installable Progressive Web App for learning Terraform and infrastructure as code. It works offline through service workers, includes interactive labs, AI coaching, progress tracking, and certification prep across AWS, GCP, Azure, Docker, Kubernetes and HashiCorp.

Placement: alphabetical, between Swahili Dictionary and Timetable.

Format follows the existing convention in the section: name as a markdown link, colon, single line description, no trailing period (matches several existing entries).

URL: https://www.terraformacademy.app/