### PR TITLE
Add PDF Mavericks (browser-local PDF tools)

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Notella](https://github.com/siddharthkp/notella): No fluff notes app.
 * [Passky](https://vault.passky.org/): Free and open-source Password Manager
 * [PasteePad](https://pasteepad.com/): Free and simple notepad app
+* [PDF Mavericks](https://pdfmavericks.com/): Free browser-local PDF toolkit — compress, merge, split, sign, watermark, redact, convert. Processing runs entirely in JavaScript via PDF.js; no file is uploaded to any server.
 * [PDFGem](https://pdfgem.io/): Free browser-based PDF tools — merge, split, compress, OCR, sign, convert. All processing runs client-side via WebAssembly; works offline after initial load. 16 languages.
 * [Pocket Devices](https://pocket-devices.com/): Pocket-sized tools for seamless functionality on the go.
 * [Pomotimer](https://pomotimer.com/): Pomodoro Technique Timer

--- a/README.md
+++ b/README.md
@@ -256,6 +256,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Passky](https://vault.passky.org/): Free and open-source Password Manager
 * [PasteePad](https://pasteepad.com/): Free and simple notepad app
 * [PDF Dark](https://pdfdark.org/): Convert PDFs to dark mode in your browser. 100% client-side, 4 themes (Midnight, Sepia, Solarized, OLED), preserves image colors. Open-source (MIT).
+* [PDF Mavericks](https://pdfmavericks.com/): Free browser-local PDF toolkit — compress, merge, split, sign, watermark, redact, convert. Processing runs entirely in JavaScript via PDF.js; no file is uploaded to any server.
 * [PDFGem](https://pdfgem.io/): Free browser-based PDF tools — merge, split, compress, OCR, sign, convert. All processing runs client-side via WebAssembly; works offline after initial load. 16 languages.
 * [Pocket Devices](https://pocket-devices.com/): Pocket-sized tools for seamless functionality on the go.
 * [Pomotimer](https://pomotimer.com/): Pomodoro Technique Timer


### PR DESCRIPTION
Adds [PDF Mavericks](https://pdfmavericks.com/) to the Tools and Utilities section.

PDF Mavericks is a free, no-account toolkit for working with PDFs entirely in the browser — compress, merge, split, sign, watermark, redact, convert. Files never leave the device; the processing runs in JavaScript via PDF.js. The site is an installable PWA with offline fallback and shortcuts for the most-used tools (compress, merge, sign).

Hope this fits the list. Happy to adjust the entry text or section.