### PR TITLE
Add PDF Dark to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Notella](https://github.com/siddharthkp/notella): No fluff notes app.
 * [Passky](https://vault.passky.org/): Free and open-source Password Manager
 * [PasteePad](https://pasteepad.com/): Free and simple notepad app
+* [PDF Dark](https://pdfdark.org/): Convert PDFs to dark mode in your browser. 100% client-side, 4 themes (Midnight, Sepia, Solarized, OLED), preserves image colors. Open-source (MIT).
 * [PDFGem](https://pdfgem.io/): Free browser-based PDF tools — merge, split, compress, OCR, sign, convert. All processing runs client-side via WebAssembly; works offline after initial load. 16 languages.
 * [Pocket Devices](https://pocket-devices.com/): Pocket-sized tools for seamless functionality on the go.
 * [Pomotimer](https://pomotimer.com/): Pomodoro Technique Timer


### PR DESCRIPTION
Adds [PDF Dark](https://pdfdark.org/) to the **Tools and Utilities** section.

**What it is:** A free, open-source converter that turns any PDF into dark mode — runs 100% client-side in the browser, no upload. 4 themes (Midnight, Sepia, Solarized, OLED), preserves image colors instead of inverting them.

**Why it fits this list:**
- Browser-based, no install, no server upload (same shape as existing entries like PDFGem, OmniConvert, Vizua, BulkPicTools)
- Source: https://github.com/1436941541/pdf-dark (MIT)
- Inserted in alphabetical order between PasteePad and PDFGem