### PR TITLE
Add ThreeFour (Tools and Utilities)

### DIFF
--- a/README.md
+++ b/README.md
@@ -225,6 +225,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Smaller Pictures](https://smaller-pictures.appspot.com): Image compressor.
 * [Super Productivity](https://app.super-productivity.com): Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration.
 * [TaleForge](https://www.tale-forge.com/): Creative writing PWA with book, manga, and screenplay editors. Works offline with service worker caching.
+* [ThreeFour](https://threefour.app): Run multi-step procedures one step at a time; it remembers where you stopped, even days later. Sequential or branching. Works offline, no account, data stays on your device. Free.
 * [Todoly](https://t4p4n.github.io/todoly/): A Simple ToDo PWA
 * [Vizua](https://vizua.io/): Free browser-based image tools — compress, resize, convert (WebP, AVIF, PNG, JPEG), remove background, upscale, OCR. 91 tools, all client-side via WebAssembly. 16 languages.
 * [Wormhole](https://wormhole.app/): Share files with end-to-end encryption.


### PR DESCRIPTION
Adds ThreeFour to ### Tools and Utilities (alphabetical, between TaleForge and Todoly).

ThreeFour is an offline-first PWA for running multi-step procedures one step at a time, with per-run state that persists between sessions. No account, no signup, data stays on-device, free.

- Live: https://threefour.app
- Serves `<link rel="manifest">` + `manifest.webmanifest` in the initial HTML, so `scripts/check-pwa.mjs` detects it; returns 200 well within the link-check timeout.

One-line addition, no other entries touched.