### PR TITLE
Add Gyeonggi Currency Map (PWA showcase)

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,6 +52,8 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 
 ## Apps
 
+
+- [Gyeonggi Currency Map](https://gyeonggi-currency-map.web.app) - Interactive PWA mapping municipal local-currency merchant locations across 31 cities of Gyeonggi Province, South Korea. Real-time "open now" filter, KakaoTalk share, public open data. React + Vite + Leaflet on Firebase Hosting.
 ### Audio and Video
 
 * [BitMidi](https://bitmidi.com): Listen to your favorite MIDI files.


### PR DESCRIPTION
Adds **Gyeonggi Currency Map** — a real-world Progressive Web App used by Gyeonggi Province (14M residents, Korea).

- URL: https://gyeonggi-currency-map.web.app
- Stack: React + Vite + Leaflet + Firebase Hosting, public open data
- PWA-installable (manifest + service worker), KakaoTalk share via JS SDK
- 31-city merchant search with real-time "open now" filter

Solo-built, freemium ad-supported. Happy to revise the section if a different placement is preferred.
