### PR TITLE
Add Shademix to Development and Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -120,6 +120,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Photopea](https://www.photopea.com/): Online Photo Editor.
 * [PixelCraft](https://pixelcraft.web.app): Pixel Art Editor
 * [Regex101](https://regex101.com/): Build, test and debug regex.
+* [Shademix](https://shademix.com): Free colour toolkit — eyedropper, 10 paint-system matcher (RAL, NCS, Pantone-equivalent), OKLCH harmonies, WCAG contrast, CMYK warnings, 11 export formats. Runs entirely client-side, no signup.
 * [SVGOMG](https://jakearchibald.github.io/svgomg/): SVGO's Missing GUI
 * [Themer](https://themer.dev): Theme generator for editors, terminals, wallpapers, and more.
 * [Total Formatter](https://totalformatter.web.app): YAML Formatter


### PR DESCRIPTION
Adding Shademix to the **Development and Design** section (alphabetical, after Regex101).

Shademix is a free colour toolkit PWA: eyedropper, 10 paint-system matcher (RAL, NCS, Pantone-equivalent), OKLCH-native harmonies, WCAG contrast, CMYK gamut warnings, Print Ready check, logo vectorizer, 11 export formats. Web + iPhone/iPad/Mac/Vision Pro. Works offline once cached as a PWA — exactly the qualification this list is built around.

Link: https://shademix.com

No signup, no telemetry, no ads. Runs entirely client-side.