### PR TITLE
Add UniStyle to Tools and Utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -226,6 +226,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Super Productivity](https://app.super-productivity.com): Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration.
 * [TaleForge](https://www.tale-forge.com/): Creative writing PWA with book, manga, and screenplay editors. Works offline with service worker caching.
 * [Todoly](https://t4p4n.github.io/todoly/): A Simple ToDo PWA
+* [UniStyle](https://unistyle.io): Convert plain text into 20+ Unicode styles (bold, italic, script, monospace) that paste anywhere Markdown is stripped. Free, no signup, installable on desktop and Android.
 * [Vizua](https://vizua.io/): Free browser-based image tools — compress, resize, convert (WebP, AVIF, PNG, JPEG), remove background, upscale, OCR. 91 tools, all client-side via WebAssembly. 16 languages.
 * [Wormhole](https://wormhole.app/): Share files with end-to-end encryption.
 * [ztable.io](https://ztable.io/): Z-Table lookup & Z-Score calculator.


### PR DESCRIPTION
Adding UniStyle to the Tools and Utilities section.

UniStyle is a free Unicode text formatter at https://unistyle.io. It converts plain text into 20+ Unicode styles (bold, italic, bold italic, script, fraktur, double-struck, monospace, small caps, vaporwave, strikethrough, underline, and more) that paste directly into any text field rendering Unicode - Discord, Notion, Twitter/X, Slack, LinkedIn, Instagram, and so on. The output is actual Unicode characters, not Markdown, so it works in fields that strip Markdown.

Why it fits the list: UniStyle is an installable PWA (web app manifest + service worker registered at the root). I confirmed it passes the conditions in `scripts/check-pwa.mjs` before submitting — the homepage at unistyle.io includes both `<link rel="manifest">` and `navigator.serviceWorker.register('./sw.js')` in the static HTML, so the CI check should pass.

- No signup, no accounts, no tracking, no ads.
- Open source: https://github.com/azmordis/simple-text-formatter
- Installable on desktop and Android.

Placed alphabetically in `## Apps > ### Tools and Utilities` between Todoly and Vizua. Happy to adjust the entry's section, format, or wording if it doesn't match the list's conventions.
