### PR TITLE
Add miTT PWA Asset Generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -378,6 +378,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [`fetch-manifest-json`](https://github.com/hemanth/fetch-manifest-json): Fetch the `mainfest.json` from an URL.
 * [`Manifest Generator`](https://brucelawson.github.io/manifest/): This simple page will generate the manifest file for you.
 * [`manifest-json`](https://www.npmjs.com/package/manifest-json): CLI tool for creating `mainfest.json`.
+* [`miTT PWA Asset Generator`](https://mittl-medien.de/pwa-asset-generator): Hosted, no-install web tool that generates PWA icons and iOS splash screens, plus optional app store icons.
 * [`PWA Asset Generator`](https://github.com/elegantapp/pwa-asset-generator): Automates PWA asset generation and image declaration. Automatically generates icon and splash screen images, favicons and mstile images.
 * [`PWAify`](https://github.com/vladikoff/PWAify): CLI tool to convert your PWA into a cross-platform desktop app.
 


### PR DESCRIPTION
Adds **miTT PWA Asset Generator** to Tools → Generators and CLIs (alphabetical position).

It's a hosted, no-install web tool that generates PWA icons and iOS splash screens from a single uploaded image, and can optionally also output App Store / Play Store icons and a feature graphic. Complements the existing CLI entry for people who prefer a browser-based generator.

https://mittl-medien.de/pwa-asset-generator
