### PR TITLE
Add Play Park to Games and Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -154,6 +154,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Memory Game PWA](https://pwa-memory-game.surge.sh/): Strengthen your memory.
 * [Murlok.io](https://murlok.io/): World of Warcraft Shadowlands.
 * [Othello](https://othello-rust.web.app/): Play Othello against the computer.
+* [Play Park](https://harborplay.us): Free family games — trivia, word puzzles, memory match, and more. No account, no ads.
 * [Player order selector](https://nenadalm.github.io/player-order-selector/): Random player order selector.
 * [Pokedex](https://pokedex.org/): Indexing Pokémon
 * [PokeQuest Wiki](https://pokequest.wiki/): Search for Pokémon


### PR DESCRIPTION
Adding Play Park (https://harborplay.us), a free family game site — trivia, word puzzles, memory match, and more. No account required, no ads, installable PWA with offline support.

Disclosure: I'm the developer of this PWA.