### PR TITLE
Add ChipBreaker to tools and utilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -202,6 +202,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Anonynote](https://anonynote.org): Note-taking app.
 * [BulkPicTools](https://bulkpictools.com): Privacy-first, browser-side bulk image optimizer and editor.
 * [Calculator](https://calculator-app-tau.vercel.app/): A calculator app with theme switcher
+* [ChipBreaker](https://chipbreaker.netlify.app/): Offline speeds & feeds and tap drill calculator for machinists — eight shop tools, zero internet. No account, no subscription.
 * [Emoji Log](https://emojilog.rosano.ca): Personal tracker
 * [Google Drive](https://drive.google.com/): File storage.
 * [Google Photos](https://photos.google.com/): Photo management.


### PR DESCRIPTION
I'm the developer of ChipBreaker. It's a free offline PWA for hobby machinists — eight shop reference tools (speeds & feeds, tap & drill, bolt circle, sine bar, materials, surface finish, calculator, converter) behind one menu. No account, no subscription, installs to the home screen and works fully offline after first load. Free / pay-what-you-want. Home page: theorbapp.com/chipbreaker/