### PR TITLE
Add webappfinder.app to App Directories

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [0data.app](https://0data.app)
 * [paquet.app](https://paquet.app/home)
 * [store.app](https://store.app/)
+* [webappfinder.app](https://webappfinder.app)
 
 ## Apps
 


### PR DESCRIPTION
Adds [Web App Finder](https://webappfinder.app) to the App Directories section.

It's a curated, ranked directory of 230+ installable web apps with verification badges (listings are machine-checked monthly for canonical URLs and cross-referenced against publishers' official channels), capability badges (offline, no account required), and per-platform install instructions. The site is itself a PWA — manifest, service worker with offline fallback, installable.

Entry keeps the section's alphabetical order and link format.