### PR TITLE
Add Recipe Jar to Health and Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -175,6 +175,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Paula](https://trypaula.com): Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling.
 * [Progressive](https://schroedingberg.github.io/progressive/): Local-first hypertrophy training tracker, fully offline and event-sourced.
 * [Progressive Beer](https://deanhume.github.io/beer/): Progressive Beer
+* [Recipe Jar](https://recipejar.app): Local-first recipe keeper. Paste a link, get a clean ad-free card, save unlimited recipes offline. No account, open source.
 * [Rewire](https://rewire-psi.vercel.app): Free private streak tracker for building better habits. Track recovery phases, earn milestones, and share progress cards.
 * [VapeFree](https://vapefree-app.vercel.app): Free private streak tracker for quitting vaping. Track lung recovery phases, milestones, and share progress.
 * [Veganify](https://veganify.app): Check if a product is vegan or not.


### PR DESCRIPTION
Adds Recipe Jar to Health and Lifestyle.

Recipe Jar is a local-first recipe keeper PWA: paste a recipe link and it saves a clean, ad-free card (ingredients and steps only) to your browser. No account, unlimited saves, and it works fully offline once installed. It also has a cook mode that keeps the screen awake and turns durations in the steps into tappable timers.

- Live: https://recipejar.app
- Source (MIT): https://github.com/sbmagar13/recipe-jar

Placed alphabetically in the section and formatted to match the surrounding entries.
