### PR TITLE
Add Archery Note to Health and Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -166,6 +166,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 ### Health and Lifestyle
 
 * [Aerko_](https://aerko.app): Offline-first, brutalist fitness & nutrition PWA with local AI biomechanics (MediaPipe) and AES-256 encryption.
+* [Archery Note](https://eita115115.github.io/archery-note/): Privacy-first archery practice notebook PWA — scoring, sight marks, equipment, and on-device AI form tracking. No account, no ads, works offline.
 * [Care Cards](https://carecards.io): Care Cards
 * [Cat Safe Foods](https://catsafefoods.com): Sharing food with your cat? Make sure it's safe first
 * [ClearLungs](https://clearlungs-app.vercel.app): Free private streak tracker for quitting smoking. Track recovery phases, milestones, and share progress.


### PR DESCRIPTION
Adding archery-note to the Health and Lifestyle section.

**Project**: Archery Note
**Repo**: https://github.com/eita115115/archery-note
**Live demo**: https://eita115115.github.io/archery-note/
**License**: Apache-2.0
**One-liner**: Privacy-first archery practice notebook PWA — scoring, sight marks, equipment, and on-device AI form tracking. No account, no ads, works offline.

**Why it fits**: It's a genuine installable PWA (static `<link rel="manifest">`, works offline) in the same spirit as other entries in this section like Progressive (local-first hypertrophy tracker) — a focused practice-tracking tool with no account or server dependency.

Happy to iterate on the wording or section placement if maintainers prefer a different format.