### PR TITLE
Add Slay PDF

### DIFF
--- a/README.md
+++ b/README.md
@@ -222,6 +222,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [QR Code Scanner](https://qrcodescan.in/): Scan a QR code.
 * [Remember](https://paulhoughton.github.io/remember/): Location-based reminders.
 * [Resume Nation](https://resume-nation.github.io): Resume creator.
+* [Slay PDF](https://slaypdf.com/): Free local PDF editor for splitting, merging, signing, resizing, posterising and editing PDFs in the browser.
 * [Smaller Pictures](https://smaller-pictures.appspot.com): Image compressor.
 * [Super Productivity](https://app.super-productivity.com): Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration.
 * [TaleForge](https://www.tale-forge.com/): Creative writing PWA with book, manga, and screenplay editors. Works offline with service worker caching.


### PR DESCRIPTION
Adds Slay PDF to Tools and Utilities.

Slay PDF is a local browser PDF editor for splitting, merging, signing, resizing, posterising and editing PDFs. It exposes a web app manifest at https://slaypdf.com/manifest.webmanifest.

Validation:
- `nix shell nixpkgs#nodejs --command node scripts/check-pwa.mjs`
- The checker verifies Slay PDF (`✅ [Tools and Utilities] Slay PDF — https://slaypdf.com/ (no SW)`).
- The command exits nonzero because six pre-existing entries are currently unreachable; no unreachable entry was introduced by this PR.