### PR TITLE
Add GameScore to Games and Entertainment

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Cybercar](https://cybercar.pages.dev): Free neon arcade survival game with power-ups, unlockable themes, boss battles, and global leaderboard.
 * [Falling Nikochan](https://nikochan.utcode.net): Simple and cute rhythm game, where anyone can create and share charts.
 * [Farmhand](https://www.farmhand.life/): A resource management game that puts a farm in your hand
+* [GameScore](https://gamescore.cards): Offline-first board game score tracker with 50+ game-specific templates and shareable Victory Cards.
 * [Life counter](https://nenadalm.github.io/life-counter/): Life counter app for 2 players. Supports game profiles, cout up/down.
 * [Match a Movie](https://match-a-movie.com/): Tinder but for movies to find out what to watch with your friends.
 * [Math Riddles](https://mathriddles.netlify.app): Interesting Math Riddles.


### PR DESCRIPTION
Adds GameScore to **Apps → Games and Entertainment** (alphabetical, between Farmhand and Life counter).

- Site: https://gamescore.cards
- Manifest: https://gamescore.cards/manifest.webmanifest (`display: standalone`, maskable + any icons at 192/512, categories: games/utilities/productivity)
- Offline-first: Workbox precaching; local-only data via IndexedDB (Dexie), no account required
- Free tier; €4.99 one-time Pro (no subscription)

Resubmission of #401 (closed while awaiting review; the fork branch was since deleted, so reopening was not possible). Happy to adjust the description or move sections if you'd prefer.
