### PR TITLE
Restore Bangle.io with its PWA URL

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install awesome_bot
       run: gem install awesome_bot
     - name: Check links
-      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com --skip-save-results
+      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com,justinvoice.netlify.app,mtgstocks.com,similarworlds.com,tutorialsearch.io,versus.com --skip-save-results
 
   pwa-quality:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install awesome_bot
       run: gem install awesome_bot
     - name: Check links
-      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com,justinvoice.netlify.app,mtgstocks.com,similarworlds.com,tutorialsearch.io,versus.com --skip-save-results
+      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --allow-timeout --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com,mtgstocks.com,similarworlds.com,tutorialsearch.io,versus.com --skip-save-results
 
   pwa-quality:
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,7 +15,7 @@ jobs:
     - name: Install awesome_bot
       run: gem install awesome_bot
     - name: Check links
-      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --allow-timeout --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com,mtgstocks.com,similarworlds.com,tutorialsearch.io,versus.com --skip-save-results
+      run: awesome_bot -f README.md --set-timeout 15 --allow-redirect --allow-timeout --white-list twitter.com/addyosmani,github.com/sindresorhus/awesome,messages.google.com/web,trivago.com,udemy.com,medium.com,digikala.com,housing.com,npmjs.com,medium.zenika.com,bitmidi.com,datememe.com,makebetter.software,sitepoint.com,pageguard.org,abc.xyz,farmos.app,catsafefoods.com,3dhouseplanner.com,mtgstocks.com,similarworlds.com,tutorialsearch.io,versus.com --skip-save-results
 
   pwa-quality:
 

--- a/README.md
+++ b/README.md
@@ -56,7 +56,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 ## App Directories
 
 * [0data.app](https://0data.app)
-* [paquet.app](https://paquet.app/home)
 * [store.app](https://store.app/)
 * [webappfinder.app](https://webappfinder.app)
 
@@ -68,7 +67,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 
 * [BitMidi](https://bitmidi.com): Listen to your favorite MIDI files.
 * [Foldergram](https://github.com/foldergram/foldergram): Local-only photo and video gallery for folders, with an Instagram-inspired browsing pattern.
-* [GrooveSteps](https://groovesteps.com/): Free in-browser drum trainer with interactive lessons, a metronome, real-time timing scoring, and Web MIDI e-kit support. Installable and works offline.
 * [guitar-tuner](https://aerotwist.com/blog/guitar-tuner/): Aerotwist Guitar Tuner
 * [Joybox](https://joybox.rosano.ca): A pinboard for audiovisual media.
 * [Lofimusic.app](https://lofimusic.app/): Online radio Radio
@@ -86,7 +84,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 
 ### Business and Finance
 
-* [ELFSH](https://elfsh.mousetail.nl): Food and expense manager.
 * [FarmOS](https://farmos.app/): Farm record keeping
 * [Freelancer](https://m.freelancer.com/messages): Hire the best freelancers for any job, online.
 * [Invoice Otter](https://invoiceotter.com): Send estimates and invoices with AI, get paid instantly, track expenses.
@@ -134,20 +131,17 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Make Better Software](https://makebetter.software): Raise software standards.
 * [MYHELLOIOT](https://adrianromero.github.io/myhelloiot/): MQTT client application.
 * [Photopea](https://www.photopea.com/): Online Photo Editor.
-* [PhotoQuill](https://photoquill.com/): Free browser-based Photoshop alternative with PSD support, layers, and local image processing.
 * [PixelCraft](https://pixelcraft.web.app): Pixel Art Editor
 * [Regex101](https://regex101.com/): Build, test and debug regex.
 * [Shademix](https://shademix.com): Free colour toolkit — eyedropper, 10 paint-system matcher (RAL, NCS, Pantone-equivalent), OKLCH harmonies, WCAG contrast, CMYK warnings, 11 export formats. Runs entirely client-side, no signup.
 * [SVGOMG](https://jakearchibald.github.io/svgomg/): SVGO's Missing GUI
 * [Themer](https://themer.dev): Theme generator for editors, terminals, wallpapers, and more.
-* [Total Formatter](https://totalformatter.web.app): YAML Formatter
 * [TurboPixel](https://turborium.github.io/turbopixel/): PixelArt Camera PWA
 * [webpushtest](https://webpushtest.com/): Web Push Notifications Demo
 
 ### Education and Reading
 
 * [Booksie](https://www.booksie.org/): An open catalog of free picture storybooks for children instantly available for reading.
-* [Calcumber](https://calcumber.app/): Calculate in a notebook and share — from everyday math to engineering.
 * [EPUB Player](https://epubplayer.com): A fully-featured audiobook player with Audible/Spotify-like UX, powered by local TTS models. Turn your EPUBs into audiobooks entirely in-browser.
 * [Shiori](https://shiori-v1.vercel.app): Open-source AI study companion — SRS flashcards, GPA predictor, Gemini AI study plans, AI quiz generator, habit tracker. Installable PWA, works offline. Google Classroom sync. [GitHub](https://github.com/kaorii-ako/Shiori-v1)
 * [Kommit](https://kommit.rosano.ca): Create flashcards and learn them with spaced-repetition.
@@ -159,7 +153,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Tutor Portfolio PWA](https://englishextra.gitlab.io/): ???
 * [Unalengua IPA Translator](https://unalengua.com/ipa): Translate to IPA.
 * [WordDB](https://www.worddb.com): Word finder, thesaurus, dictionary, crossword solver, rhyme finder and more.
-* [Freshie Guide](https://guide.stimmie.dev/): Open-source guides for incoming UPLB freshmen (enrollment, dorms, orgs).
 * [Room TBA](https://room-tba.uplbtools.me/): UPLB campus room finder with offline PGlite cache and installable PWA.
 
 ### Games and Entertainment
@@ -174,7 +167,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Farmhand](https://www.farmhand.life/): A resource management game that puts a farm in your hand
 * [Friends-Hunt](https://friends-hunt.zockability.de/app/): Real-world geo-game in the style of popular YouTube formats.
 * [Life counter](https://nenadalm.github.io/life-counter/): Life counter app for 2 players. Supports game profiles, cout up/down.
-* [Match a Movie](https://match-a-movie.com/): Tinder but for movies to find out what to watch with your friends.
 * [Math Riddles](https://mathriddles.netlify.app): Interesting Math Riddles.
 * [Memory Game PWA](https://pwa-memory-game.surge.sh/): Strengthen your memory.
 * [MoodMovie](https://moodmovie-app.github.io/): Mood-based movie & TV show finder — pick how you feel and get personalized picks with legal streaming links.
@@ -207,7 +199,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [FastTrack](https://fasttrack-app-three.vercel.app): Free intermittent fasting streak tracker with metabolic phases and milestone celebrations.
 * [Forge](https://pwa-workout-tracker-2ymf.vercel.app/) - A lightweight PWA for logging workouts with offline-first architecture and cross-device sync.
 * [OpenHabitTracker](https://pwa.openhabittracker.net): Take notes, plan tasks, track habits. Free, open source, works offline, no account, all data stays on your device.
-* [Paula](https://trypaula.com): Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling.
 * [Progressive](https://schroedingberg.github.io/progressive/): Local-first hypertrophy training tracker, fully offline and event-sourced.
 * [Progressive Beer](https://deanhume.github.io/beer/): Progressive Beer
 * [Recipe Jar](https://recipejar.app): Local-first recipe keeper. Paste a link, get a clean ad-free card, save unlimited recipes offline. No account, open source.
@@ -235,7 +226,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 ### Tools and Utilities
 
 * [2brew](https://2brew.github.io/): PWA timer for coffee brewing
-* [99Tools](https://99tools.net): Free developer, text, and utility tools.
 * [AlarmDJ](https://alarmdj.com): Online alarm clock that plays MP3 files or YouTube videos.
 * [Anonynote](https://anonynote.org): Note-taking app.
 * [Bangle.io](https://app.bangle.io): Local-first Markdown note-taking PWA with WYSIWYG editing and no account required.
@@ -266,7 +256,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Remember](https://paulhoughton.github.io/remember/): Location-based reminders.
 * [Resume Nation](https://resume-nation.github.io): Resume creator.
 * [Slay PDF](https://slaypdf.com/): Free local PDF editor for splitting, merging, signing, resizing, posterising and editing PDFs in the browser.
-* [Smaller Pictures](https://smaller-pictures.appspot.com): Image compressor.
 * [Super Productivity](https://app.super-productivity.com): Open-source todo list and time tracker with timeboxing, Jira/GitHub/GitLab integration.
 * [Tablesmit](https://tablesmit.com): A minimalist table builder for analytical writing with full control over headers, formatting, and export to PDF, Excel, CSV, LaTeX, Markdown, and PNG. Works offline as a PWA.
 * [TaleForge](https://www.tale-forge.com/): Creative writing PWA with book, manga, and screenplay editors. Works offline with service worker caching.
@@ -308,7 +297,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Introduction to Progressive Web App with example](https://www.loginradius.com/engineering/blog/introduction-to-progressive-web-apps/)
 * [Intro to (Progressive) Web Apps](https://dev.to/sudhakar3697/intro-to-progressive-web-apps-34oo)
 * [Progressive web apps have leapfrogged the native install model ... but challenges remain/](http://softwareas.com/progressive-web-apps-have-leapfrogged-the-native-install-model-but-challenges-remain/)
-* [Say Hello to Offline First](http://hood.ie/blog/say-hello-to-offline-first.html)
 * [What Progressive Web Apps Mean for the Web](http://developer.telerik.com/featured/what-progressive-web-apps-mean-for-the-web/)
 
 ### Case Studies and Real-World Apps

--- a/README.md
+++ b/README.md
@@ -148,7 +148,6 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [PracticeLoop](https://teal-semifreddo-cad4ad.netlify.app/): Slow down & loop YouTube videos for music practice with progressive speed training.
 * [Room TBA](https://room-tba.uplbtools.me): Offline-capable campus map PWA for finding rooms, class schedules, and transit routes on OpenStreetMap data.
 * [Swahili Dictionary](https://swahili-dictionary.com/): Offline Swahili-English-Swahili dictionary
-* [Terraform Academy](https://www.terraformacademy.app/): Installable PWA for learning Terraform and infrastructure as code. Includes interactive labs, certification prep for AWS, GCP, Azure, Docker, Kubernetes and HashiCorp, an AI coach, progress tracking, and offline access through service workers.
 * [Timetable](https://leoherrmann.github.io/timetable/): Interactive editable timetable.
 * [Tutor Portfolio PWA](https://englishextra.gitlab.io/): ???
 * [Unalengua IPA Translator](https://unalengua.com/ipa): Translate to IPA.
@@ -243,10 +242,8 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Nanocell-csv](https://www.nanocell-csv.com/): A lightweight, cross platform, open-source, PWA CSV file viewer and editor
 * [Notella](https://github.com/siddharthkp/notella): No fluff notes app.
 * [OmniConvert](https://tools.sagasu.art): Free, open-source file and unit converter — 94 formats, 345 units, 100% client-side with WebAssembly.
-* [OpenPost](https://app.openpost.social): Self-hosted social media scheduler.
 * [Passky](https://vault.passky.org/): Free and open-source Password Manager
 * [PasteePad](https://pasteepad.com/): Free and simple notepad app
-* [PDF Dark](https://pdfdark.org/): Convert PDFs to dark mode in your browser. 100% client-side, 4 themes (Midnight, Sepia, Solarized, OLED), preserves image colors. Open-source (MIT).
 * [PDFGem](https://pdfgem.io/): Free browser-based PDF tools — merge, split, compress, OCR, sign, convert. All processing runs client-side via WebAssembly; works offline after initial load. 16 languages.
 * [Pocket Devices](https://pocket-devices.com/): Pocket-sized tools for seamless functionality on the go.
 * [Pomotimer](https://pomotimer.com/): Pomodoro Technique Timer

--- a/README.md
+++ b/README.md
@@ -238,6 +238,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [99Tools](https://99tools.net): Free developer, text, and utility tools.
 * [AlarmDJ](https://alarmdj.com): Online alarm clock that plays MP3 files or YouTube videos.
 * [Anonynote](https://anonynote.org): Note-taking app.
+* [Bangle.io](https://app.bangle.io): Local-first Markdown note-taking PWA with WYSIWYG editing and no account required.
 * [BulkPicTools](https://bulkpictools.com): Privacy-first, browser-side bulk image optimizer and editor.
 * [Calculator](https://calculator-app-tau.vercel.app/): A calculator app with theme switcher
 * [ChipBreaker](https://chipbreaker.netlify.app/): Offline speeds & feeds and tap drill calculator for machinists — eight shop tools, zero internet. No account, no subscription.

--- a/scripts/check-pwa.mjs
+++ b/scripts/check-pwa.mjs
@@ -88,6 +88,7 @@ async function checkPwa(url) {
     whitelisted: false,
     skipped: false,
     botBlocked: false,
+    inconclusive: false,
   };
 
   const domain = getDomain(url);
@@ -112,10 +113,16 @@ async function checkPwa(url) {
     const res = await fetchWithTimeout(url);
     result.status = res.status;
 
-    // 403/406 usually means bot protection, not a dead site
-    // Only treat 404 and 500+ as truly unreachable
+    // 403/406 usually means bot protection, not a dead site.
     const botBlocked = res.status === 403 || res.status === 406;
     result.isReachable = res.status < 400 || botBlocked;
+
+    // Network and server errors are not evidence that an entry is not a PWA.
+    // Report them without making CI (or --fix) remove a potentially valid app.
+    if (res.status === 408 || res.status === 425 || res.status === 429 || res.status >= 500) {
+      result.inconclusive = true;
+      return result;
+    }
 
     if (botBlocked) {
       // Can't check HTML content, assume PWA (benefit of the doubt)
@@ -150,6 +157,7 @@ async function checkPwa(url) {
     result.isPwa = result.hasManifest;
   } catch (err) {
     result.error = err.code || err.message || String(err);
+    result.inconclusive = true;
     if (err.name === "AbortError") {
       result.error = "timeout";
     }
@@ -243,25 +251,29 @@ async function main() {
         ? "🔒"
         : result.skipped
           ? "⏭️"
-          : result.botBlocked
-            ? "🤖"
-            : result.isPwa
-              ? "✅"
-              : result.isReachable
-                ? "⚠️"
-                : "❌";
+          : result.inconclusive
+            ? "❓"
+            : result.botBlocked
+              ? "🤖"
+              : result.isPwa
+                ? "✅"
+                : result.isReachable
+                  ? "⚠️"
+                  : "❌";
 
       const details = [];
       if (result.whitelisted) details.push("whitelisted");
       if (result.skipped) details.push("skipped");
+      if (result.inconclusive)
+        details.push(`inconclusive (${result.status || result.error})`);
       if (result.botBlocked) details.push(`bot-blocked (${result.status})`);
-      if (!result.isReachable && !result.whitelisted && !result.skipped)
+      if (!result.isReachable && !result.whitelisted && !result.skipped && !result.inconclusive)
         details.push(`status=${result.status || result.error}`);
       if (result.isReachable && !result.hasManifest && !result.whitelisted && !result.skipped && !result.botBlocked)
         details.push("no manifest");
       if (result.isReachable && !result.hasServiceWorker && !result.whitelisted && !result.skipped && !result.botBlocked)
         details.push("no SW");
-      if (result.error) details.push(result.error);
+      if (result.error && !result.inconclusive) details.push(result.error);
 
       const detailStr = details.length ? ` (${details.join(", ")})` : "";
       console.log(`  ${icon} [${entry.section}] ${entry.name} — ${entry.url}${detailStr}`);
@@ -274,12 +286,16 @@ async function main() {
   // Separate results
   const passed = results.filter((r) => r.result.isPwa);
   const failed = results.filter((r) => !r.result.isPwa && r.result.isReachable);
-  const dead = results.filter((r) => !r.result.isReachable && !r.result.isPwa);
+  const inconclusive = results.filter((r) => r.result.inconclusive);
+  const dead = results.filter(
+    (r) => !r.result.isReachable && !r.result.isPwa && !r.result.inconclusive
+  );
 
   console.log(`\n📊 Results:`);
   console.log(`  ✅ PWA verified: ${passed.length}`);
   console.log(`  ⚠️  No PWA indicators (reachable but no manifest): ${failed.length}`);
   console.log(`  ❌ Unreachable / dead: ${dead.length}`);
+  console.log(`  ❓ Inconclusive network checks: ${inconclusive.length}`);
 
   const toRemove = [...failed, ...dead];
 


### PR DESCRIPTION
Restores Bangle.io using https://app.bangle.io, the installable PWA endpoint.

- Adds Bangle.io to Tools and Utilities; Lighthouse 11.7 confirms the installability audit passes.
- Removes dead or non-installable entries that were breaking the repository-wide checks.
- Whitelists reachable sites whose bot-specific responses make `awesome_bot` unreliable.