### PR TITLE
Add CuidaLocal to Health and Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -169,6 +169,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Care Cards](https://carecards.io): Care Cards
 * [Cat Safe Foods](https://catsafefoods.com): Sharing food with your cat? Make sure it's safe first
 * [ClearLungs](https://clearlungs-app.vercel.app): Free private streak tracker for quitting smoking. Track recovery phases, milestones, and share progress.
+* [CuidaLocal](https://marcosmmjr2023.github.io/kit-organizacao-cuidados/cuidalocal/): Local-first, offline caregiver organizer with accessible simple and full modes, calendar export, and local reminders.
 * [Dog Safe Foods](https://dogsafefoods.com): Sharing food with your dog? Make sure it's safe first
 * [DoHabit](https://inikann.github.io/DoHabit/): Straightforward habit tracker.
 * [FastTrack](https://fasttrack-app-three.vercel.app): Free intermittent fasting streak tracker with metabolic phases and milestone celebrations.

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Care Cards](https://carecards.io): Care Cards
 * [Cat Safe Foods](https://catsafefoods.com): Sharing food with your cat? Make sure it's safe first
 * [ClearLungs](https://clearlungs-app.vercel.app): Free private streak tracker for quitting smoking. Track recovery phases, milestones, and share progress.
-* [CuidaLocal](https://marcosmmjr2023.github.io/kit-organizacao-cuidados/cuidalocal/): Local-first, offline caregiver organizer with accessible simple and full modes, calendar export, and local reminders.
+* [CuidaLocal](https://marcosmmjr2023.github.io/kit-organizacao-cuidados/cuidalocal-en/): Local-first, offline caregiver organizer in English with accessible simple and full modes, calendar export, and local reminders.
 * [Dog Safe Foods](https://dogsafefoods.com): Sharing food with your dog? Make sure it's safe first
 * [DoHabit](https://inikann.github.io/DoHabit/): Straightforward habit tracker.
 * [FastTrack](https://fasttrack-app-three.vercel.app): Free intermittent fasting streak tracker with metabolic phases and milestone celebrations.


### PR DESCRIPTION
## Summary

Adds **CuidaLocal**, an English local-first caregiver organizer, to the Health and Lifestyle apps section.

Public English PWA: https://marcosmmjr2023.github.io/kit-organizacao-cuidados/cuidalocal-en/

It provides offline use after the first load; accessible Simple and Full views; local browser storage without an account; organization for appointments, medicines, contacts, and backups; and device-calendar export with clearly documented reminder limits.

## Verification

- The public English PWA returns HTTP 200.
- It includes an English manifest and offline service-worker shell.
- A Portuguese edition remains linked inside the app.