### PR TITLE
Add Chompass under Health and Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -194,6 +194,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Archery Note](https://eita115115.github.io/archery-note/): Privacy-first archery practice notebook PWA — scoring, sight marks, equipment, and on-device AI form tracking. No account, no ads, works offline.
 * [Care Cards](https://carecards.io): Care Cards
 * [Cat Safe Foods](https://catsafefoods.com): Sharing food with your cat? Make sure it's safe first
+* [Chompass](https://chompass.app/app/): Ad-free calorie and food diary PWA. local-first diary and body metrics, optional BYOK AI, open JSON export. No account required.
 * [ClearLungs](https://clearlungs-app.vercel.app): Free private streak tracker for quitting smoking. Track recovery phases, milestones, and share progress.
 * [CuidaLocal](https://marcosmmjr2023.github.io/kit-organizacao-cuidados/cuidalocal-en/): Local-first, offline caregiver organizer in English with accessible simple and full modes, calendar export, and local reminders.
 * [Dog Safe Foods](https://dogsafefoods.com): Sharing food with your dog? Make sure it's safe first


### PR DESCRIPTION
i also added a issue idk how you handle this here.
disclosure: im the maintainer :)

Add Chompass under Health and Lifestyle (alphabetically between Cat Safe Foods and ClearLungs).

Chompass is an installable PWA for calorie / food diary logging (manual, photo, barcode, voice). Data stays in the browser; optional AI uses a user-supplied API key. Companion Android app shares open JSON export formats. No backend, no ads, no analytics.

licence: MIT
Source: https://codeberg.org/fitguy/Chompass
PWA: https://chompass.app/app/
website: https://chompass.app
Closes: #453 