### PR TITLE
Add QuoteChime to Business and Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -93,6 +93,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [JustInvoice](https://justinvoice.netlify.app/app): An intuitive invoice manager that works completely in the browser and offline.
 * [MoneyTracker](https://moneytracker.cc/): Personal finances tracking web app.
 * [MTGStocks](https://www.mtgstocks.com/news): Magic the Gathering price tracker.
+* [QuoteChime](https://quotechime.pages.dev/?ref=awesomepwa): Draft finite quote follow-up sequences privately in the browser. Free core, no signup, and works offline after first load.
 * [Rydeen](https://rydeen.app/): Task management app for individuals.
 * [Simple Currency Converter](https://currency-converter.now.sh): Currency Converter
 * [Skcript](https://www.skcript.com/): Ruby on Rails Consulting.


### PR DESCRIPTION
Adds QuoteChime to Business and Finance in alphabetical order.

The linked app is an HTTPS PWA with a web app manifest, registered service worker, responsive layout, and offline support for its free browser-private quote follow-up generator. Core use requires no account; the project also has an MIT-licensed open-source edition.