### PR TITLE
Add Termdeck under Development and Design

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,6 +139,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Regex101](https://regex101.com/): Build, test and debug regex.
 * [Shademix](https://shademix.com): Free colour toolkit — eyedropper, 10 paint-system matcher (RAL, NCS, Pantone-equivalent), OKLCH harmonies, WCAG contrast, CMYK warnings, 11 export formats. Runs entirely client-side, no signup.
 * [SVGOMG](https://jakearchibald.github.io/svgomg/): SVGO's Missing GUI
+* [Termdeck](https://termdeck.io): Browser control plane for the Claude Code, Codex and Grok coding-agent CLIs running on your own machines. Installable, with Web Push notifications when an agent needs a tool approved.
 * [Themer](https://themer.dev): Theme generator for editors, terminals, wallpapers, and more.
 * [Total Formatter](https://totalformatter.web.app): YAML Formatter
 * [TurboPixel](https://turborium.github.io/turbopixel/): PixelArt Camera PWA


### PR DESCRIPTION
Adds Termdeck to Apps → Development and Design, in alphabetical order (between SVGOMG and Themer).

Termdeck is a browser control plane for the Claude Code, Codex and Grok coding-agent CLIs running on your own machines. The part relevant to this list: it is an installable PWA with a service-worker shell and Web Push, so when an agent pauses for a tool approval the notification lands on a phone and can be answered there — with no browser tab left open.

https://termdeck.io