### PR TITLE
Add Push or Pay to Health and Lifestyle

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,6 +210,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [Paula](https://trypaula.com): Free AI mental health companion using CBT and DBT techniques, with voice sessions, mood tracking, and journaling.
 * [Progressive](https://schroedingberg.github.io/progressive/): Local-first hypertrophy training tracker, fully offline and event-sourced.
 * [Progressive Beer](https://deanhume.github.io/beer/): Progressive Beer
+* [Push or Pay](https://pushorpay.netlify.app): Free couples streak-tracking PWA. Protect your daily push-up streak or your partner collects a playful "Lazy Tax." No account beyond an invite link, works offline.
 * [Recipe Jar](https://recipejar.app): Local-first recipe keeper. Paste a link, get a clean ad-free card, save unlimited recipes offline. No account, open source.
 * [Rewire](https://rewire-psi.vercel.app): Free private streak tracker for building better habits. Track recovery phases, earn milestones, and share progress cards.
 * [VapeFree](https://vapefree-app.vercel.app): Free private streak tracker for quitting vaping. Track lung recovery phases, milestones, and share progress.


### PR DESCRIPTION
Push or Pay is a free couples streak-tracking PWA — protect a daily push-up streak or your partner collects a playful "Lazy Tax." No account beyond an invite link, works offline (manifest.json + service worker registered, verified live).

Added alphabetically between Progressive Beer and Recipe Jar, matching the section's existing one-line description style and the pattern of same-shape entries already listed (ClearLungs, FastTrack, Rewire, VapeFree).