### PR TITLE
Add tingdo to Business and Finance

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,6 +97,7 @@ _Source:_ [Google Developers - Progressive Web Apps](https://developers.google.c
 * [SplittyPie](https://splittypie.com): Easy expense splitting.
 * [Taskade](https://www.taskade.com): Remote Team Workspace.
 * [Tender](https://app.tender.run/create-account): Personal finance app.
+* [tingdo](https://web.tingdo.app): GTD task manager — what's next instead of fake due dates. Tasks sorted by situation, reviewed weekly.
 * [TuxBank](https://tuxbank.app): Budget calendar, local first, optional e2ee sync.
 * [Vaulted](https://vaultedworth.com): Local-first net worth tracker PWA with no account, no bank sync, and no server.
 * [WalletLens](https://walletlens.live) — Net worth tracker PWA — crypto, stocks, gold, fiat, cash. Installable, works offline, no account required.


### PR DESCRIPTION
Adds tingdo, a GTD task manager, to Business and Finance — next to Rydeen and Taskade, which cover similar ground.

PWA criteria:
- HTTPS ✓
- Web app manifest ✓ — `<link rel="manifest" href="/manifest.json">` is present in the served HTML, so `scripts/check-pwa.mjs` detects it without needing a whitelist entry
- Installable on desktop and mobile, no app store ✓
- Works offline ✓
- Responsive ✓

On the URL: I linked `web.tingdo.app` rather than the `tingdo.app` marketing site on purpose. The marketing page is a static Astro build with no manifest, so the PWA checker would flag it; `web.tingdo.app` is the actual app and passes the check. This matches how Tender and JustInvoice are linked in the same section.

Entry is placed alphabetically between Tender and TuxBank.

Disclosure: I work on tingdo.
